### PR TITLE
DNS timeout fix

### DIFF
--- a/inference/docker/deploy.yaml
+++ b/inference/docker/deploy.yaml
@@ -34,6 +34,7 @@ spec:
         - name: secrets
           mountPath: /root/.cloudvolume/secrets
           readOnly: true
+      dnsPolicy: Default
       volumes:
       - name: secrets
         secret:


### PR DESCRIPTION
Work-around for DNS timeout issues, for more details, see https://github.com/kubernetes/kubernetes/issues/56903

Note: The default value for `dnsPolicy` is not `Default`, but `ClusterFirst`.