### PR TITLE
GPU semaphore

### DIFF
--- a/inference/args.py
+++ b/inference/args.py
@@ -12,7 +12,9 @@ def get_argparser():
   parser = argparse.ArgumentParser()
   parser.add_argument('--queue_name', type=str, default=None)
   parser.add_argument('--processes', type=positive_int, default=1,
-     help='no. of processes to use on a single worker (useful to bypass GKE GPU limit)')
+     help='no. of processes to spawn on a single worker')
+  parser.add_argument('--gpu_processes', type=positive_int, default=None,
+     help='max no. of processes that might share the GPU at any given time')
   parser.add_argument('--threads', type=int, default=1,
      help='no. of threads to use in scheduling chunks (locally & distributed)')
   parser.add_argument('--task_batch_size', type=int, default=1,

--- a/inference/tasks.py
+++ b/inference/tasks.py
@@ -148,10 +148,9 @@ class ComputeFieldTask(RegisteredTask):
     start = time()
     if not aligner.dry_run:
       field = aligner.compute_field_chunk(model_path, src_cv, tgt_cv, src_z, tgt_z, 
-      		                          patch_bbox, mip, pad, 
+                                          patch_bbox, mip, pad, 
                                           src_mask_cv, src_mask_mip, src_mask_val,
                                           tgt_mask_cv, tgt_mask_mip, tgt_mask_val)
-      field = field.data.cpu().numpy()
       aligner.save_field(field, field_cv, src_z, patch_bbox, mip, relative=False)
       with Storage(field_cv.path) as stor:
         path = 'compute_field_done/{}/{}'.format(prefix, patch_bbox.stringify(src_z))

--- a/inference/worker.py
+++ b/inference/worker.py
@@ -2,7 +2,7 @@ import atexit
 import os
 import signal
 import sys
-from multiprocessing import Event, Process
+from multiprocessing import Event, Process, Semaphore
 from time import sleep, time
 
 from taskqueue import TaskQueue
@@ -80,6 +80,7 @@ if __name__ == '__main__':
   parser = get_argparser()
   aligner_args = parse_args(parser)
   process_count = aligner_args.processes
+  gpu_process_count = aligner_args.gpu_processes or process_count
 
   if process_count == 1:
     run_aligner(aligner_args)
@@ -88,6 +89,9 @@ if __name__ == '__main__':
     signal.signal(signal.SIGTERM, cleanup_processes)
 
     print("Preparing {} processes...".format(process_count))
+    print("GPU will be shared by up to {} processes".format(gpu_process_count))
+
+    aligner_args.gpu_lock = Semaphore(gpu_process_count)
     for process_id in range(process_count):
       create_process(process_id, aligner_args)
 

--- a/inference/worker.py
+++ b/inference/worker.py
@@ -107,6 +107,8 @@ if __name__ == '__main__':
             create_process(process_id, aligner_args)
         elif p.exitcode != 0:
           # Worker got killed unexpectedly - probably an uncaught exception.
+          # TODO: If the worker got killed by force while using a gpu_lock
+          # we could run into a deadlock.
           print("Process {} terminated with code {}. Restarting...".format(process_id, p.exitcode))
           create_process(process_id, aligner_args)
         else:


### PR DESCRIPTION
- introduce `gpu_processes` parameter to set the number of processes that are allowed to ~use the GPU~ run inference concurrently, without blocking other processes from downloading, uploading etc.
  - hopefully mitigates `CUDA out of memory` errors
  - assumes that calculating the vector field is the only significant memory cost

- changes return value of `compute_vector_field` from tensor (device) to np.ndarray (host)

TODO:
- Deal with crashes/interrupts while lock(s) acquired
- Look for other memory intensive operations