### PR TITLE
Grid sample refactor

### DIFF
--- a/inference/aligner.py
+++ b/inference/aligner.py
@@ -24,7 +24,7 @@ import torch.nn as nn
 
 from normalizer import Normalizer
 from temporal_regularization import create_field_bump
-from utilities.helpers import save_chunk, crop, upsample, gridsample_residual, \
+from utilities.helpers import save_chunk, crop, upsample, grid_sample, \
                               np_downsample, invert, compose_fields, upsample_field, \
                               is_identity, cpc, vector_vote, get_affine_field
 from boundingbox import BoundingBox, deserialize_bbox
@@ -668,7 +668,7 @@ class Aligner:
                                 mask_cv=mask_cv, mask_mip=mask_mip,
                                 mask_val=mask_val,
                                 to_tensor=True, normalizer=None)
-        image = gridsample_residual(image, field, padding_mode='zeros')
+        image = grid_sample(image, field, padding_mode='zeros')
         image = image[:,:,pad:-pad,pad:-pad]
         return image
 

--- a/inference/test_helpers.py
+++ b/inference/test_helpers.py
@@ -45,7 +45,7 @@ class TestInvert(unittest.TestCase):
     U = torch.zeros((1,2,2,2))
     V = invert(U)
     # V = V.permute((0,3,1,2))
-    # UofV = gridsample_residual(V, U, padding_mode='border')
+    # UofV = grid_sample(V, U, padding_mode='border')
     # UofV = UofV.permute((0,2,3,1))
     eq = tensor_approx_eq(U, V)
     self.assertTrue(eq)

--- a/training/architecture.py
+++ b/training/architecture.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-from utilities.helpers import gridsample_residual, upsample, downsample, load_model_from_dict
+from utilities.helpers import grid_sample, upsample, downsample, load_model_from_dict
 
 
 class Model(nn.Module):
@@ -260,12 +260,12 @@ class AligningPyramid(nn.Module):
                 accum_field = (upsample(prev_level - i)
                                (accum_field.permute(0, 3, 1, 2))
                                .permute(0, 2, 3, 1))
-                src = gridsample_residual(src, accum_field,
+                src = grid_sample(src, accum_field,
                                           padding_mode='border')
             factor = 2 / src.shape[-1]  # scale to [-1,1]
             res_field = aligner(src, tgt, **kwargs) * factor
             if accum_field is not None:
-                resampled = gridsample_residual(
+                resampled = grid_sample(
                     accum_field.permute(0, 3, 1, 2), res_field,
                     padding_mode='border').permute(0, 2, 3, 1)
                 accum_field = res_field + resampled

--- a/training/objective.py
+++ b/training/objective.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 from utilities import masklib
 from training.loss import smoothness_penalty
-from utilities.helpers import gridsample_residual
+from utilities.helpers import grid_sample
 
 
 class Objective(nn.Module):
@@ -99,14 +99,14 @@ class SelfSupervisedLoss(nn.Module):
         src = sample.src.image.to(prediction.device)
         tgt = sample.tgt.image.to(prediction.device)
 
-        src_warped = gridsample_residual(src, prediction, padding_mode='zeros')
+        src_warped = grid_sample(src, prediction, padding_mode='zeros')
         image_loss_map = (src_warped - tgt)**2
         if src_masks or tgt_masks:
             image_weights = torch.ones_like(image_loss_map)
             if src_masks is not None:
                 for mask in src_masks:
                     try:
-                        mask = gridsample_residual(mask, prediction,
+                        mask = grid_sample(mask, prediction,
                                                    padding_mode='border')
                         image_loss_map = image_loss_map * mask
                         image_weights = image_weights * mask
@@ -132,7 +132,7 @@ class SelfSupervisedLoss(nn.Module):
             if src_field_masks is not None:
                 for mask in src_field_masks:
                     try:
-                        mask = gridsample_residual(mask, prediction,
+                        mask = grid_sample(mask, prediction,
                                                    padding_mode='border')
                         field_loss_map = field_loss_map * mask
                         field_weights = field_weights * mask

--- a/training/stack_dataset.py
+++ b/training/stack_dataset.py
@@ -5,7 +5,7 @@ import torch
 from torch.utils.data import Dataset, ConcatDataset
 
 from aug import aug_input, rotate_and_scale, random_translation
-from utilities.helpers import (upsample, downsample, gridsample_residual,
+from utilities.helpers import (upsample, downsample, grid_sample,
                                dotdict)
 
 
@@ -174,7 +174,7 @@ class RandomField(object):
         field = upsample(self.num_downsamples)(field)
         X.truth = field.permute(0, 2, 3, 1)
         for k in X.tgt:
-            X.tgt[k] = gridsample_residual(
+            X.tgt[k] = grid_sample(
                 X.src[k], X.truth, padding_mode='zeros')
         return X
 

--- a/training/train.py
+++ b/training/train.py
@@ -81,7 +81,7 @@ from pathlib import Path
 
 import stack_dataset
 from utilities.archive import ModelArchive
-from utilities.helpers import (gridsample_residual, save_chunk,
+from utilities.helpers import (grid_sample, save_chunk,
                                dvl as save_vectors, AverageMeter,
                                retry_enumerate, cp, dotdict)
 
@@ -384,7 +384,7 @@ def create_debug_outputs(archive, sample, prediction, id=0):
             cp(debug_dir / 'tgt_aug_{}.png'.format(id), stack_dir)
         else:
             cp(debug_dir / 'tgt_{}.png'.format(id), stack_dir)
-        warped_src = gridsample_residual(
+        warped_src = grid_sample(
             src[0:1, ...],
             prediction[0:1, ...].detach().to(src.device),
             padding_mode='zeros')

--- a/utilities/helpers.py
+++ b/utilities/helpers.py
@@ -474,18 +474,25 @@ def identity_grid(size, cache=False, device=None):
         return Id
 
     if isinstance(size, torch.Size):
+        batch_dim = size[0]
         if (size[2] == size[3]  # image
                 or (size[3] == 2 and size[1] == size[2])):  # field
             size = size[2]
         else:
-            raise ValueError("Bad size: {}. Expected a square tensor size.".format(size))
+            raise ValueError("Bad size: {}. Expected a square tensor size."
+                             .format(size))
+    else:
+        batch_dim = 1
     if device is None:
         device = torch.cuda.current_device()
     if size in identity_grid._identities:
-        return identity_grid._identities[size].copy().to(device)
-    Id = _create_identity_grid(size, device)
-    if cache:
-        identity_grid._identities[size] = Id.copy()
+        Id = identity_grid._identities[size].copy()
+    else:
+        Id = _create_identity_grid(size, device)
+        if cache:
+            identity_grid._identities[size] = Id.copy()
+    if batch_dim > 1:
+        Id = torch.cat([Id] * batch_dim)
     return Id.to(device)
 identity_grid._identities = {}
 


### PR DESCRIPTION
Refactor the grid sampling code including the following changes:
- `gridsample_residual()` renamed to `grid_sample()`.
I modified all the locations in the code I could find to call `grid_sample()`, and any new code (such as new models) should be switched as well. `gridsample_residual()` still works for now but prints a warning message. 
- Explicit function for grid sampling from vector fields `grid_sample_field()`
- Allow grid sampling on either GPU or CPU
- Allow grid sampling in batches
That is, the first dimension (the batch dimension) is now allowed to be non-singular. Each input image `i` in the batch is grid sampled with the corresponding `i`th vector field. This should be efficient, since it just uses the underlying PyTorch grid sampler. We just weren't taking advantage of it before