### PR TITLE
Contiguous chunk boundaries with affine transform support

### DIFF
--- a/inference/aligner.py
+++ b/inference/aligner.py
@@ -119,11 +119,9 @@ class Aligner:
       padded_bbox = deepcopy(bbox)
       x_range = padded_bbox.x_range(mip=0)
       y_range = padded_bbox.y_range(mip=0)
-      #print("x_range is", x_range, "y_range is", y_range)
-      new_bbox = BoundingBox(x_range[0] + dis[1], x_range[1] + dis[1],
-                                   y_range[0] + dis[0], y_range[1] + dis[0],
-                                   mip=0)
-      #print(new_bbox.x_range(mip=0), new_bbox.y_range(mip=0))
+      new_bbox = BoundingBox(x_range[0] + dis[0], x_range[1] + dis[0],
+                             y_range[0] + dis[1], y_range[1] + dis[1],
+                             mip=0)
       return new_bbox
 
   ##############

--- a/inference/boundingbox.py
+++ b/inference/boundingbox.py
@@ -73,8 +73,8 @@ class BoundingBox:
  
   def get_offset(self, mip=0):
     scale_factor = 2**mip
-    return (floor(self.m0_x[0] / scale_factor) + floor(self.m0_x_size / 2 / scale_factor),
-            floor(self.m0_y[0] / scale_factor) + floor(self.m0_y_size / 2 / scale_factor))
+    return (self.m0_x[0] / scale_factor + self.m0_x_size / 2 / scale_factor,
+            self.m0_y[0] / scale_factor + self.m0_y_size / 2 / scale_factor)
 
   def x_range(self, mip):
     assert(mip <= self.max_mip)

--- a/inference/upsample_render.py
+++ b/inference/upsample_render.py
@@ -6,6 +6,7 @@ from os.path import join
 import numpy as np
 from cloudmanager import CloudManager
 from tasks import run
+import json
 
 def print_run(diff, n_tasks):
   if n_tasks > 0:
@@ -64,20 +65,10 @@ if __name__ == '__main__':
   if args.affine_lookup:
     affine_lookup = {}
     with open(args.affine_lookup) as f:
-      reader = csv.reader(f, delimiter=',')
-      for k, r in enumerate(reader):
-        if k != 0:
-          a11 = float(r[0])
-          a12 = float(r[1])
-          a13 = float(r[2])
-          a21 = float(r[3])
-          a22 = float(r[4])
-          a23 = float(r[5])
-          z_start = int(r[6])
-          z_stop  = int(r[7])
-          affine = np.array([[a11,a12,a13],[a21,a22,a23]])
-          for z in range(z_start, z_stop):
-            affine_lookup[z] = affine
+      affine_list = json.load(f)
+      for aff in affine_list:
+        z = aff['z']
+        affine_lookup[z] = np.array(aff['transform'])
 
   # Render sections
   k = 0
@@ -102,4 +93,5 @@ if __name__ == '__main__':
       k = 0
       a.wait_for_sqs_empty()
   if len(batch) > 0:
+    print('Scheduling RenderTasks up to z={}'.format(z))
     run(a, batch)


### PR DESCRIPTION
- add @macrintr JSON reader / fixes from branch `tmacrina-mip2-render`
- refactor `cloudsample_image` using absolute coordinates (rather than [-1,+1]) for the affine transformation.

Supersedes #84 