### PR TITLE
fix(cloudsample_compose): Wrong tensor size for identity input

### DIFF
--- a/inference/aligner.py
+++ b/inference/aligner.py
@@ -800,7 +800,7 @@ class Aligner:
                            relative=False, to_tensor=True)
         if g_mip > dst_mip:
             g = upsample_field(g, g_mip, dst_mip)
-        return g
+        return g[:,pad:-pad,pad:-pad,:]
 
       distance = self.profile_field(f)
       distance = (distance // (2 ** g_mip)) * 2 ** g_mip


### PR DESCRIPTION
`cloudsample_compose` short-circuits when the warping field is the identity field, directly returning the upsampled, to-be-warped input field. But it doesn't crop it back to the original size.